### PR TITLE
Revert "Temporary downgrade version to upload artefacts"

### DIFF
--- a/.github/workflows/mac_latest.yml
+++ b/.github/workflows/mac_latest.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  v8_version: 10.8.168.21
+  v8_version: 11.0.226.16
 
 jobs:
 

--- a/.github/workflows/ubuntu_latest.yml
+++ b/.github/workflows/ubuntu_latest.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  v8_version: 10.8.168.21
+  v8_version: 11.0.226.16
 
 jobs:
 


### PR DESCRIPTION
The macOS artefacts are available now, hence there is no need for this commit anymore.