### PR TITLE
Fix linux build get stuck when waiting for input.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN sed -i 's/"--short"].decode().strip())/"--short"]).decode().strip()/g' ./bui
 RUN sed -i 's/"\/sbin\/init"].decode()):/"\/sbin\/init"]).decode():/g' ./build/install-build-deps.py
 # not need to install snap.
 RUN sed -i 's/packages.append("snapcraft")/pass/g' ./build/install-build-deps.py
+RUN DEBIAN_FRONTEND=noninteractive apt-get install keyboard-configuration
 RUN ./build/install-build-deps.sh --no-prompt
 COPY build_linux_${ARCH}.${BUILD_TYPE}.bash .
 RUN /bin/bash ./build_linux_${ARCH}.${BUILD_TYPE}.bash


### PR DESCRIPTION
Fix build failure: https://github.com/RedisGears/v8-build/actions/runs/7068163710/job/19242438539
The issue is that when installing `keyboard-configuration` (added recently). The installation waits for user input. To avoid this we install it separately and set `DEBIAN_FRONTEND` env var to `noninteractive` as suggested on: https://askubuntu.com/questions/876240/how-to-automate-setting-up-of-keyboard-configuration-package